### PR TITLE
Revert "ci: 👷 ignore `inspector-issues` to vercel preview urls"

### DIFF
--- a/.github/.lighthouserc.yml
+++ b/.github/.lighthouserc.yml
@@ -5,8 +5,7 @@ ci:
       preset: desktop
       onlyCategories: ['performance', 'seo', 'accessibility', 'best-practices']
       # skipping is-crawlable since vercel will prevent indexing on non prod urls
-      # skipping inspector-issues since vercel preview url add a login capability
-      skipAudits: ['is-crawlable', 'inspector-issues']
+      skipAudits: ['is-crawlable']
   assert:
     assertions:
       categories:performance:


### PR DESCRIPTION
This reverts commit 6e06e00ff36e3c32cf44c8015d1b2dedd33fdc65.